### PR TITLE
Changes Requested for Keycard DIP 

### DIFF
--- a/DIPs/DIP-5.md
+++ b/DIPs/DIP-5.md
@@ -1,6 +1,6 @@
 ---
 Title: Keycard at Devcon
-Status: Draft
+Status: Changes Requested
 Primary Contact: guylouis@status.im
 Themes: Ticketing, Purchase & ID
 Tags: Attendee Experience


### PR DESCRIPTION
We are looking forward to implementing a Keycard system at Devcon, however there are some elements we would like to discuss & that will be conditional to accepting the DIP.

1. Will both the iOS and Android Status apps have keycard integration ready by mid-2021? Historically around ~60% of our attendees have used iOS, so iOS support being ready would be ideal.

2. We have a community and not a marketing approach for DIPs. 

    - We would like to ensure that the Keycard designs could align with the Devcon brand - or with a community-created design, incorporating the Status/Keycard logo to some degree.

    - Though Status will likely be the de facto wallet to onboard and withdraw assets, we would prefer not to pigeonhole people. Is it possible for attendees to use other apps to withdraw their assets from their Keycard?

    - Will the Keycard be "unlocked" / developer mode? 

3. Could your Product / Design team add in your DIP how they envision the user journey and integration throughout Devcon? Do you have any Colombia-specific research insights that could potentially be used to create a better narrative locally and / or craft opportunities for other use cases during and after Devcon?