### PR TITLE
Update DIP-9.md

### DIFF
--- a/DIPs/DIP-9.md
+++ b/DIPs/DIP-9.md
@@ -1,7 +1,7 @@
 ---
 DIP: 9
 Title: Devcon 5.1
-Status: Draft
+Status: Rejected
 Theme: Virtual Experience
 Tags: Other
 Authors: <Cristian Espinoza> @crisgarner


### PR DESCRIPTION
Thanks for your DIP and your enthusiasm to keep the community growing and sharing during this peculiar year. 
We thought long and hard when realising the event wouldn't be able to take place IRL this year on if we should virtualise it or not. We decided not to for several reasons that you can read [here](https://blog.ethereum.org/2020/05/28/devcon-hacia-colombia-en-2021/). However, as you rightfully mentioned, a lot of stuff has happened this year and we want to support other community-based events. One event we are supporting is ETHGlobal's [ETHOnline](https://ethonline.org/) which will take place during the entire month of October with a hackathon *and* talks. It will be accessible to everyone so we encourage you to check it out!
Thanks again!