### PR TITLE
Bumped spellcheck GitHub action to version 0.20.0

### DIFF
--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -9,5 +9,5 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@master
-    - uses: rojopolis/spellcheck-github-actions@0.5.0
+    - uses: rojopolis/spellcheck-github-actions@0.20.0
       name: Spellcheck


### PR DESCRIPTION
I have recently released 0.20.0 of the spellcheck GitHub action, I can see that you are using 0.5.0, so an update could be useful to you. Let me know if you have any issues with the proposal and I will try to accommodate.

I can recommend [Dependabot](https://github.com/dependabot) for keeping your GitHub actions up to date, if you want a PR proposing a basic configuration, please let me know.