### PR TITLE
Dependabot config for GH Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+# Basic dependabot.yml file
+# REF: https://docs.github.com/en/code-security/supply-chain-security/keeping-your-actions-up-to-date-with-dependabot
+
+version: 2
+updates:
+  # Enable version updates for GitHubb Actions
+  - package-ecosystem: "github-actions"
+    # Look for `.github/workflows` in the `root` directory
+    directory: "/"
+    # Check for updates once a week
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
Initial revision of a suggestion for a configuration for Dependabot for GitHub Actions. It is based on the one I use myself, it checks weekly, which can of course be changed to suit your repository.

jonasbn