### PR TITLE
docs: create dip-30 give climate friendly poap holders a perk

### DIFF
--- a/DIPs/DIP-30.md
+++ b/DIPs/DIP-30.md
@@ -1,0 +1,35 @@
+---
+DIP: 30
+Title: "Climate Friendly Devcon VI" POAP Holders Get Priority in the Vegetarian Lunch Queue
+Status: Draft
+Themes: Environmental Sustainability
+Tags: Event production
+Authors: danceratopz <danceratopz@gmail.com>, haurog <haurog@pm.me>
+Resources Required: Operational support
+Discussion: https://forum.devcon.org/t/climate-friendly-devcon-vi-poap-holders-get-priority-in-the-vegetarian-lunch-queue/1601
+Created: 2022-10-09
+---
+
+## Summary of Proposal / Abstract
+
+As proposed in [DIP-17](./DIP-17.md) (Accepted) the "Climate Friendly Devcon VI" Dapp allows Devcon VI attendees to optionally compensate the carbon emissions associated with the event and their air travel to the event on-chain. Attendees who compensated (at least) their event emissions may mint a POAP as proof of participation. This DIP proposes that holders of this POAP receive priority treatment in the queue for vegetarian lunch on the last day of Devcon VI. 
+
+## Rationale
+
+This provides a perk to POAP holders to encourage participation amongst attendees to offset their carbon emissions.
+
+## Implementation
+
+Participants must show their POAP in either the POAP, Rainbow, or welook App at the lunch queue.
+
+danceratopz & haurog would verify POAP holders at either 1 or 2 of the vegetarian lunch queues. 
+
+## Operational Requirements & Ownership
+
+In order for this perk to have impact, we aks whether it would be possible to advertise the initiative on the main stage on the last day of Devcon and/or in the Agora Center LED banner.
+
+danceratopz & haurog would take full ownership of verifying POAP holders in the lunch queue.
+
+## Links & Additional Information
+
+The Climate Friendly Devcon VI [POAP event](https://poap.gallery/event/71937).

--- a/DIPs/DIP-30.md
+++ b/DIPs/DIP-30.md
@@ -1,6 +1,6 @@
 ---
 DIP: 30
-Title: "Climate Friendly Devcon VI" POAP Holders Get Priority in the Vegetarian Lunch Queue
+Title: "Climate Friendly Devcon VI" POAP Holders get lunch priority
 Status: Draft
 Themes: Environmental Sustainability
 Tags: Event production

--- a/DIPs/DIP-30.md
+++ b/DIPs/DIP-30.md
@@ -26,7 +26,7 @@ danceratopz & haurog would verify POAP holders at either 1 or 2 of the vegetaria
 
 ## Operational Requirements & Ownership
 
-In order for this perk to have impact, we aks whether it would be possible to advertise the initiative on the main stage on the last day of Devcon and/or in the Agora Center LED banner.
+In order for this perk to have impact, we ask whether it would be possible to advertise the initiative on the last day of Devcon and/or in the Agora Center LED banner.
 
 danceratopz & haurog would take full ownership of verifying POAP holders in the lunch queue.
 

--- a/DIPs/DIP-30.md
+++ b/DIPs/DIP-30.md
@@ -20,7 +20,7 @@ This provides a perk to POAP holders to encourage participation amongst attendee
 
 ## Implementation
 
-Participants must show their POAP in either the POAP, Rainbow, or welook App at the lunch queue.
+Participants must show their POAP at the lunch queue.
 
 danceratopz & haurog would verify POAP holders at either 1 or 2 of the vegetarian lunch queues. 
 


### PR DESCRIPTION
As proposed in DIP-17 (Accepted) the “Climate Friendly Devcon VI” Dapp allows Devcon VI attendees to optionally compensate the carbon emissions associated with the event on-chain.

Attendees who compensated (at least) their event emissions may mint a POAP as proof that they participated.

This DIP proposes that holders of this POAP receive priority treatment in the queue for vegetarian lunch.